### PR TITLE
use RetryLink default st. to handle request to server multiple time 

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,9 @@ import {
   InMemoryCache,
   createHttpLink,
   split,
+  from,
 } from '@apollo/client'
+import { RetryLink } from '@apollo/client/link/retry'
 import { getMainDefinition } from '@apollo/client/utilities'
 import { GraphQLWsLink } from '@apollo/client/link/subscriptions'
 import { createClient } from 'graphql-ws'
@@ -60,7 +62,16 @@ const App = () => {
 
   const httpLink = createHttpLink({ uri: import.meta.env.VITE_BACKEND_URL })
 
+  const httpLinkWithRetry = from([
+    new RetryLink(),
+    httpLink
+  ])
+
   const wsLink = new GraphQLWsLink(createClient({ url: import.meta.env.VITE_GRAPHQLWSLINK }))
+  const wsLinkWithRetry = from([
+    new RetryLink(),
+    wsLink
+  ])
 
   const splitLink = split(
     ({ query }) => {
@@ -70,8 +81,8 @@ const App = () => {
         definition.operation === 'subscription'
       )
     },
-    wsLink,
-    authLink.concat(httpLink),
+    wsLinkWithRetry,
+    authLink.concat(httpLinkWithRetry),
   )
 
   const client = new ApolloClient({


### PR DESCRIPTION
RetryLink from apollo/client/link/retry can be used to retry an operation a certain amount of times. 
The default is attempts 5 time, should be enough.